### PR TITLE
Add cloud platform information

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: ZhijunZhao
   company: Microsoft
   description: "latest Azure modules for provisioning Azure resources"
-  galaxy_tags: ["Azure", "cloud", "system", "development", "networking", "docker", "container", "kubernetes"]
+  galaxy_tags: ["azure", "cloud", "system", "development", "networking", "docker", "container", "kubernetes"]
   license: MIT
   min_ansible_version: "2.5.0"
   platforms:
@@ -29,3 +29,5 @@ galaxy_info:
       versions: 
         - 2012R2
 
+  cloud_platforms:
+    - Azure


### PR DESCRIPTION
At the right bottom of the [galaxy hub](https://galaxy.ansible.com/search?deprecated=false&order_by=-relevance&keywords=), user can select the cloud  filter