### PR TITLE
Adding support for Inbound Nat Rules for azure_rm_networkinterface

### DIFF
--- a/library/azure_rm_networkinterface.py
+++ b/library/azure_rm_networkinterface.py
@@ -152,6 +152,12 @@ options:
                     - Can be written as a resource ID.
                     - Also can be a dict of I(name) and I(load_balancer).
                 version_added: '2.6'
+            load_balancer_inbound_nat_rules:
+                description:
+                    - List of existing load-balancer inbound nat rules to associate with the network interface.
+                    - Can be written as a resource ID.
+                    - Also can be a dict of I(name) and I(load_balancer).
+                version_added: '2.9'
             primary:
                 description:
                     - Whether the IP configuration is the primary one in the list.
@@ -380,6 +386,10 @@ state:
                     description:
                         - List of existing load-balancer backend address pools to associate with the network interface.
                     type: list
+                load_balancer_inbound_nat_rules:
+                    description:
+                        - List of existing load-balancer inbound nat rules to associate with the network interface.
+                    type: list
                 private_ip_address:
                     description:
                         - Private IP address for the IP configuration.
@@ -486,6 +496,8 @@ def nic_to_dict(nic):
             primary=config.primary,
             load_balancer_backend_address_pools=([item.id for item in config.load_balancer_backend_address_pools]
                                                  if config.load_balancer_backend_address_pools else None),
+            load_balancer_inbound_nat_rules=([item.id for item in config.load_balancer_inbound_nat_rules]
+                                                 if config.load_balancer_inbound_nat_rules else None),
             public_ip_address=dict(
                 id=config.public_ip_address.id,
                 name=azure_id_to_dict(config.public_ip_address.id).get('publicIPAddresses'),
@@ -529,6 +541,7 @@ ip_configuration_spec = dict(
     public_ip_address_name=dict(type='str', aliases=['public_ip_address', 'public_ip_name']),
     public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
     load_balancer_backend_address_pools=dict(type='list'),
+    load_balancer_inbound_nat_rules=dict(type='list'),
     primary=dict(type='bool', default=False),
     application_security_groups=dict(type='list', elements='raw')
 )
@@ -754,6 +767,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         load_balancer_backend_address_pools=([self.network_models.BackendAddressPool(id=self.backend_addr_pool_id(bap_id))
                                                               for bap_id in ip_config.get('load_balancer_backend_address_pools')]
                                                              if ip_config.get('load_balancer_backend_address_pools') else None),
+                        load_balancer_inbound_nat_rules=([self.network_models.InboundNatRule(id=self.inbound_nat_rule_id(inr_id))
+                                                              for inr_id in ip_config.get('load_balancer_inbound_nat_rules')]
+                                                             if ip_config.get('load_balancer_inbound_nat_rules') else None),
                         primary=ip_config.get('primary'),
                         application_security_groups=([self.network_models.ApplicationSecurityGroup(id=asg_id)
                                                       for asg_id in ip_config.get('application_security_groups')]
@@ -853,6 +869,20 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                                    child_name_1=name)
         return val
 
+    def inbound_nat_rule_id(self, val):
+        if isinstance(val, dict):
+            lb = val.get('load_balancer', None)
+            name = val.get('name', None)
+            if lb and name:
+                return resource_id(subscription=self.subscription_id,
+                                   resource_group=self.resource_group,
+                                   namespace='Microsoft.Network',
+                                   type='loadBalancers',
+                                   name=lb,
+                                   child_type_1='inboundNatRules',
+                                   child_name_1=name)
+        return val
+
     def construct_ip_configuration_set(self, raw):
         configurations = [str(dict(
             private_ip_allocation_method=to_native(item.get('private_ip_allocation_method')),
@@ -862,6 +892,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             load_balancer_backend_address_pools=(set([to_native(self.backend_addr_pool_id(id))
                                                       for id in item.get('load_balancer_backend_address_pools')])
                                                  if item.get('load_balancer_backend_address_pools') else None),
+            load_balancer_inbound_nat_rules=(set([to_native(self.inbound_nat_rule_id(id))
+                                                                  for id in item.get('load_balancer_inbound_nat_rules')])
+                                                             if item.get('load_balancer_inbound_nat_rules') else None),
             application_security_groups=(set([to_native(asg_id) for asg_id in item.get('application_security_groups')])
                                          if item.get('application_security_groups') else None),
             name=to_native(item.get('name'))

--- a/library/azure_rm_networkinterface_facts.py
+++ b/library/azure_rm_networkinterface_facts.py
@@ -155,6 +155,10 @@ networkinterfaces:
                 load_balancer_backend_address_pools:
                     description:
                         - List of existing load-balancer backend address pools to associate with the network interface.
+                load_balancer_inbound_nat_rules:
+                    description:
+                        - List of existing load-balancer inbound nat rules to associate with the network interface.
+                    version_added: '2.9'
                 primary:
                     description:
                         - Whether the IP configuration is the primary one in the list.
@@ -225,6 +229,8 @@ def nic_to_dict(nic):
             primary=config.primary,
             load_balancer_backend_address_pools=([item.id for item in config.load_balancer_backend_address_pools]
                                                  if config.load_balancer_backend_address_pools else None),
+            load_balancer_inbound_nat_rules=([item.id for item in config.load_balancer_inbound_nat_rules]
+                                                             if config.load_balancer_inbound_nat_rules else None),
             public_ip_address=config.public_ip_address.id if config.public_ip_address else None,
             public_ip_allocation_method=config.public_ip_address.public_ip_allocation_method if config.public_ip_address else None,
             application_security_groups=([asg.id for asg in config.application_security_groups]

--- a/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -521,6 +521,138 @@
       name: "{{ nic_name1 }}"
       state: absent
 
+- name: create public ip
+  azure_rm_publicipaddress:
+    name: "pip2{{ rpfx }}"
+    resource_group: '{{ resource_group }}'
+
+- name: create load balancer with multiple parameters (Inbound Nat Rules)
+  azure_rm_loadbalancer:
+    resource_group: '{{ resource_group }}'
+    name: "lb2{{ rpfx }}"
+    frontend_ip_configurations:
+      - name: frontendipconf0
+        public_ip_address: "pip2{{ rpfx }}"
+    backend_address_pools:
+      - name: backendaddrpool0
+      - name: backendaddrpool1
+    probes:
+      - name: prob0
+        port: 80
+    inbound_nat_rules:
+      - name: lbrnatrule0
+        backend_port: 9080
+        frontend_port: 9080
+        frontend_ip_configuration: frontendipconf0
+      - name: lbrnatrule1
+        backend_port: 9081
+        frontend_port: 9081
+        frontend_ip_configuration: frontendipconf0
+  register: lb2
+
+- name: Create NIC (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn2{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      create_with_security_group: False
+      public_ip: False
+  register: output
+
+- assert:
+    that:
+      - output.changed
+
+- name: Get fact of the new created NIC
+  azure_rm_networkinterface_facts:
+    resource_group: "{{ resource_group }}"
+    name: "tn2{{ rpfx }}"
+  register: facts
+
+- name: Update NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn2{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      enable_accelerated_networking: True
+      enable_ip_forwarding: True
+      security_group: "tn{{ rpfx }}sg"
+      dns_servers:
+        - 8.9.10.11
+        - 7.8.9.10
+      ip_configurations:
+          - name: "{{ facts.networkinterfaces[0].ip_configurations[0].name }}"
+            private_ip_address: "{{ facts.networkinterfaces[0].ip_configurations[0].private_ip_address }}"
+            private_ip_allocation_method: "{{ facts.networkinterfaces[0].ip_configurations[0].private_ip_allocation_method }}"
+            primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
+          - name: ipconfig1
+            public_ip_name: "tn{{ rpfx }}"
+            load_balancer_inbound_nat_rules:
+              - "{{ lb2.state.inbound_nat_rules[0].id }}"
+              - name: lbrnatrule1
+                load_balancer: "lb2{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.ip_configurations | json_query('[?name==`ipconfig1`]')
+      - output.state.ip_configurations | json_query('[?name==`ipconfig1`].load_balancer_inbound_nat_rules')
+
+- name: Complicated NIC (idempontent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn2{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      enable_accelerated_networking: True
+      security_group: "tn{{ rpfx }}sg"
+      enable_ip_forwarding: True
+      dns_servers:
+        - 8.9.10.11
+        - 7.8.9.10
+      ip_configurations:
+          - name: "{{ facts.networkinterfaces[0].ip_configurations[0].name }}"
+            private_ip_address: "{{ facts.networkinterfaces[0].ip_configurations[0].private_ip_address }}"
+            private_ip_allocation_method: "{{ facts.networkinterfaces[0].ip_configurations[0].private_ip_allocation_method }}"
+            primary: "{{ facts.networkinterfaces[0].ip_configurations[0].primary }}"
+          - name: ipconfig1
+            public_ip_name: "tn{{ rpfx }}"
+            load_balancer_inbound_nat_rules:
+              - "{{ lb2.state.inbound_nat_rules[0].id }}"
+              - name: lbrnatrule1
+                load_balancer: "lb2{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+
+- name: Delete the NIC (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn2{{ rpfx }}"
+      state: absent
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+
+- name: delete load balancer
+  azure_rm_loadbalancer:
+    resource_group: '{{ resource_group }}'
+    name: "lb2{{ rpfx }}"
+    state: absent
+
+- name: delete public ip
+  azure_rm_publicipaddress:
+    name: "pip2{{ rpfx }}"
+    resource_group: '{{ resource_group }}'
+    state: absent
+
 - name: Delete the application security group (check mode)
   azure_rm_applicationsecuritygroup:
       resource_group: "{{ resource_group }}"


### PR DESCRIPTION
Hello.

I'm having a case here at work where I need to attach Inbound Nat Rules to a network interface, and was frustrated to use the REST API.
Please note that it's my very first public Pull Request (so please excuse the mistakes).
IMPORTANT : My access to azure doesn't allow me to create/manage public ip addresses or virtual networks, so I tried my best to craft test tasks, and hope they are working well ... (I tested them with limited access as much as I can though)

Best Regards.