### PR TITLE
Sort the version list

### DIFF
--- a/library/azure_rm_aksversion_facts.py
+++ b/library/azure_rm_aksversion_facts.py
@@ -112,7 +112,9 @@ class AzureRMAKSVersion(AzureRMModuleBase):
             if version:
                 return result.get(version) or []
             else:
-                return result.keys()
+                keys = list(result.keys())
+                keys.sort() 
+                return keys
         except Exception as exc:
             self.fail('Error when getting AKS supported kubernetes version list for location {0} - {1}'.format(self.location, exc.message or str(exc)))
 


### PR DESCRIPTION
Actually, when performing a get_all_versions function it returns a version list unsorted.
This could help to get version applying [-1] on the list  to recover the latest version of Kubernetes Service