### PR TITLE
Fix bug that charset and collation are not set (Azure Database for PostgreSQL)

### DIFF
--- a/library/azure_rm_postgresqldatabase.py
+++ b/library/azure_rm_postgresqldatabase.py
@@ -245,6 +245,8 @@ class AzureRMPostgreSqlDatabases(AzureRMModuleBase):
             response = self.mgmt_client.databases.create_or_update(resource_group_name=self.resource_group,
                                                                    server_name=self.server_name,
                                                                    database_name=self.name,
+                                                                   charset=self.parameters.get('charset', None),
+                                                                   collation=self.parameters.get('collation', None),
                                                                    parameters=self.parameters)
             if isinstance(response, LROPoller):
                 response = self.get_poller_result(response)


### PR DESCRIPTION
When creating a database with azure_rm_postgresqldatabase, charset and collapse are ignored. They are set to 'UTF8` and `English_United States.1252` respectively.

```
$ ansible-playbook database.yml  
$ az postgres db create -g postgres -s postgres981 -n db2 --charset SQL_ASCII --collation C

$ az postgres db list -g postgres -s postgres981 --output table
Charset    Collation                   Name               ResourceGroup
---------  --------------------------  -----------------  ---------------
UTF8       English_United States.1252  postgres           postgres
UTF8       English_United States.1252  azure_maintenance  postgres
UTF8       English_United States.1252  azure_sys          postgres
UTF8       English_United States.1252  ansible            postgres
SQL_ASCII  C                           db2                postgres
```

```yaml
# database.yml
- name: Azure Database for PostgreSQL
  hosts: localhost
  connection: local
  tasks:
    - name: Create Resource Group
      azure_rm_resourcegroup:
        name: postgres
        location: japaneast
    - name: Create PostgreSQL Server
      azure_rm_postgresqlserver:
        name: postgres981
        resource_group: postgres
        sku:
          name: B_Gen5_1
          tier: Basic
        location: japaneast
        admin_username: foobar
        admin_password: P@ssw0rd
    - name: Create Database
      azure_rm_postgresqldatabase:
        name: ansible
        resource_group: postgres
        server_name: postgres981
        collation: C
        charset: SQL_ASCII
```
